### PR TITLE
Api migration - OAuth Flow

### DIFF
--- a/app/api/workspace/add/route.ts
+++ b/app/api/workspace/add/route.ts
@@ -4,7 +4,7 @@ import { auth } from "@/lib/auth";
 
 export async function POST() {
   try {
-    const url = await auth.api.signInWithOAuth2({
+    const { url } = await auth.api.signInWithOAuth2({
       body: {
         providerId: "slack_oauth2_v2",
         callbackURL: "/dashboard",

--- a/app/api/workspace/add/route.ts
+++ b/app/api/workspace/add/route.ts
@@ -4,7 +4,7 @@ import { auth } from "@/lib/auth";
 
 export async function POST() {
   try {
-    await auth.api.signInWithOAuth2({
+    const url = await auth.api.signInWithOAuth2({
       body: {
         providerId: "slack_oauth2_v2",
         callbackURL: "/dashboard",
@@ -13,7 +13,7 @@ export async function POST() {
       },
     });
 
-    return NextResponse.json({ success: true });
+    return NextResponse.json({ url });
   } catch (err) {
     console.error(err);
 

--- a/app/api/workspace/add/route.ts
+++ b/app/api/workspace/add/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from "next/server";
+
+import { auth } from "@/lib/auth";
+
+export async function POST() {
+  try {
+    await auth.api.signInWithOAuth2({
+      body: {
+        providerId: "slack_oauth2_v2",
+        callbackURL: "/dashboard",
+        errorCallbackURL: "/error",
+        disableRedirect: false,
+      },
+    });
+
+    return NextResponse.json({ success: true });
+  } catch (err) {
+    console.error(err);
+
+    return NextResponse.json(
+      { success: false, error: "OAuth failed" },
+      { status: 500 },
+    );
+  }
+}

--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -1,6 +1,4 @@
 import "@/styles/globals.css";
-import { cookies } from "next/headers";
-import { redirect } from "next/navigation";
 
 import { Header } from "@/components/dashboard/header/header";
 import { Toolbar } from "@/components/dashboard/toolbar/toolbar";

--- a/components/dashboard/main/main-content-container.tsx
+++ b/components/dashboard/main/main-content-container.tsx
@@ -11,7 +11,7 @@ import { GridView } from "@/components/dashboard/content/grid/grid-view";
 import { cn } from "@/lib/utils";
 import { BaseDrawer } from "@/components/drawers/dashboard/base-drawer";
 import { useWorkspace } from "@/hooks/use-workspace";
-import SlackLogo from "@/assets/slack-logo.png";
+import SlackLogo from "@/public/SLA-appIcon-desktop.png";
 import { useAuth } from "@/hooks/use-auth";
 
 export function MainContentContainer() {

--- a/components/dashboard/main/main-content-container.tsx
+++ b/components/dashboard/main/main-content-container.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { useEffect, useCallback, useRef } from "react";
+import { Button } from "@heroui/button";
+import Image from "next/image";
 
 import { useFiles } from "@/hooks/use-files";
 import { useUIStore } from "@/stores/ui-store";
@@ -8,12 +10,18 @@ import { useInfiniteScroll } from "@/hooks/use-infinite-scroll";
 import { GridView } from "@/components/dashboard/content/grid/grid-view";
 import { cn } from "@/lib/utils";
 import { BaseDrawer } from "@/components/drawers/dashboard/base-drawer";
+import { useWorkspace } from "@/hooks/use-workspace";
+import SlackLogo from "@/assets/slack-logo.png";
+import { useAuth } from "@/hooks/use-auth";
 
 export function MainContentContainer() {
   const { loadFiles, isLoading, hasMore } = useFiles();
   const viewMode = useUIStore((state) => state.viewMode);
 
   const mainContainerRef = useRef<HTMLDivElement>(null);
+
+  const { session } = useAuth();
+  const { addWorkspace, loading: workspaceLoading } = useWorkspace();
 
   useEffect(() => {
     loadFiles(false);
@@ -49,11 +57,35 @@ export function MainContentContainer() {
           viewMode === "grid" ? "bg-zinc-100 dark:bg-zinc-800 p-4" : "p-6",
         )}
       >
-        {viewMode === "grid" && (
+        {!session?.user?.workspaceId ? (
+          <div className="flex flex-col items-center justify-center h-full gap-6 p-8 rounded-2xl border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-900 shadow-md">
+            <h2 className="text-2xl font-semibold text-slate-900 dark:text-slate-100">
+              Connect a Workspace
+            </h2>
+            <p className="text-center text-slate-600 dark:text-slate-400 max-w-md">
+              You don’t have a workspace connected yet. Click below to add your
+              Slack workspace and start using the app.
+            </p>
+            <Button
+              className="flex items-center justify-center gap-2 w-full max-w-xs rounded-lg px-4 py-3 text-slate-900 font-medium border border-zinc-300 bg-white shadow-sm hover:shadow-md transition-shadow"
+              isLoading={workspaceLoading}
+              onPress={() => addWorkspace()}
+            >
+              <Image alt="Slack Logo" height={24} src={SlackLogo} width={24} />
+              {workspaceLoading
+                ? "...Authenticating with Slack"
+                : "Continue with Slack"}
+            </Button>
+          </div>
+        ) : (
           <>
-            <GridView />
-            <div className="h-32 boder-8 border-red-900 z-50" />
-            <div className="boder-8 border-red-900" data-sentinel="true" />
+            {viewMode === "grid" && (
+              <>
+                <GridView />
+                <div className="h-32 boder-8 border-red-900 z-50" />
+                <div className="boder-8 border-red-900" data-sentinel="true" />
+              </>
+            )}
           </>
         )}
         <BaseDrawer containerRef={mainContainerRef} />

--- a/hooks/use-auth.ts
+++ b/hooks/use-auth.ts
@@ -2,7 +2,6 @@
 
 import { useState, useCallback, useRef, useEffect } from "react";
 
-import { slackScopesConfig } from "@/config/scopes";
 import { authClient } from "@/lib/auth/client";
 import {
   UseAuthReturn,
@@ -46,7 +45,6 @@ export function useAuth(): UseAuthReturn {
     try {
       const { data, error } = await authClient.signIn.social({
         provider: "slack",
-        scopes: slackScopesConfig,
       });
 
       if (error) {

--- a/hooks/use-workspace.ts
+++ b/hooks/use-workspace.ts
@@ -13,7 +13,11 @@ export function useWorkspace() {
     try {
       const response = await fetch("/api/workspace/add", { method: "POST" });
 
-      if (!response.ok) throw new Error("Failed to start OAuth");
+      const data = await response.json();
+
+      if (!response.ok || !data.url) throw new Error("Failed to start OAuth");
+
+      window.location.href = data.url;
 
       return { success: true };
     } catch (err: any) {

--- a/hooks/use-workspace.ts
+++ b/hooks/use-workspace.ts
@@ -1,0 +1,35 @@
+"use client";
+
+import { useState, useCallback } from "react";
+
+export function useWorkspace() {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const addWorkspace = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const response = await fetch("/api/workspace/add", { method: "POST" });
+
+      if (!response.ok) throw new Error("Failed to start OAuth");
+
+      return { success: true };
+    } catch (err: any) {
+      const e = err instanceof Error ? err : new Error("Unknown error");
+
+      setError(e);
+
+      return { success: false, error: e };
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  return {
+    loading,
+    error,
+    addWorkspace,
+  };
+}

--- a/lib/auth/client.ts
+++ b/lib/auth/client.ts
@@ -1,5 +1,9 @@
+import type { auth } from "@/lib/auth";
+
 import { createAuthClient } from "better-auth/react";
+import { inferAdditionalFields } from "better-auth/client/plugins";
 
 export const authClient = createAuthClient({
   baseURL: process.env.NEXT_PUBLIC_APP_URL + "/api/auth",
+  plugins: [inferAdditionalFields<typeof auth>()],
 });

--- a/lib/auth/index.ts
+++ b/lib/auth/index.ts
@@ -1,8 +1,9 @@
 import { betterAuth } from "better-auth";
 import { MongoClient } from "mongodb";
 import { mongodbAdapter } from "better-auth/adapters/mongodb";
-import { slackScopesConfig } from "@/config/scopes";
 import { genericOAuth } from "better-auth/plugins";
+
+import { slackScopesConfig } from "@/config/scopes";
 
 export interface SlackOAuthResponse {
   ok: boolean;
@@ -54,6 +55,7 @@ export const auth = betterAuth({
           providerId: "slack_oauth2_v2",
           clientId: process.env.SLACK_CLIENT_ID as string,
           clientSecret: process.env.SLACK_CLIENT_SECRET as string,
+          redirectURI: process.env.SLACK_OUTH_2_V2_REDIRECT_URI as string,
           authorizationUrl: "https://slack.com/oauth/v2/authorize",
           tokenUrl: "https://slack.com/api/oauth.v2.access",
           responseType: "code",

--- a/lib/auth/index.ts
+++ b/lib/auth/index.ts
@@ -1,6 +1,31 @@
 import { betterAuth } from "better-auth";
 import { MongoClient } from "mongodb";
 import { mongodbAdapter } from "better-auth/adapters/mongodb";
+import { slackScopesConfig } from "@/config/scopes";
+import { genericOAuth } from "better-auth/plugins";
+
+export interface SlackOAuthResponse {
+  ok: boolean;
+  access_token: string;
+  token_type: "bot" | string;
+  scope: string;
+  bot_user_id: string;
+  app_id: string;
+  team: {
+    name: string;
+    id: string;
+  };
+  enterprise?: {
+    name: string;
+    id: string;
+  };
+  authed_user: {
+    id: string;
+    scope: string;
+    access_token: string;
+    token_type: "user" | string;
+  };
+}
 
 const client = new MongoClient(process.env.MONGO_URI as string);
 const db = client.db(process.env.MONGO_DB_NAME);
@@ -22,4 +47,23 @@ export const auth = betterAuth({
       workspaceId: { type: "string", required: false, input: false },
     },
   },
+  plugins: [
+    genericOAuth({
+      config: [
+        {
+          providerId: "slack_oauth2_v2",
+          clientId: process.env.SLACK_CLIENT_ID as string,
+          clientSecret: process.env.SLACK_CLIENT_SECRET as string,
+          authorizationUrl: "https://slack.com/oauth/v2/authorize",
+          tokenUrl: "https://slack.com/api/oauth.v2.access",
+          responseType: "code",
+          responseMode: "query",
+          prompt: "consent",
+          pkce: true,
+          accessType: "offline",
+          scopes: slackScopesConfig,
+        },
+      ],
+    }),
+  ],
 });

--- a/lib/auth/index.ts
+++ b/lib/auth/index.ts
@@ -22,9 +22,4 @@ export const auth = betterAuth({
       workspaceId: { type: "string", required: false, input: false },
     },
   },
-  databaseHooks: {
-    user: {
-      // look into tomorrow lol
-    },
-  },
 });

--- a/services/db/models/userworkspace.model.ts
+++ b/services/db/models/userworkspace.model.ts
@@ -1,0 +1,30 @@
+import mongoose, { Schema, Document } from "mongoose";
+
+type RoleEnum = "owner" | "member";
+
+export interface IUserWorkspace extends Document {
+  workspaceId: string;
+  userId: string;
+  role: RoleEnum;
+}
+
+const UserWorkspaceSchema = new Schema<IUserWorkspace>(
+  {
+    workspaceId: { type: String, required: true },
+    userId: { type: String, required: true },
+    role: {
+      type: String,
+      enum: ["owner", "member"],
+      required: true,
+      default: "member",
+    },
+  },
+  { timestamps: true },
+);
+
+// Prevent duplicate user-workspace pairs
+UserWorkspaceSchema.index({ workspaceId: 1, userId: 1 }, { unique: true });
+
+export const UserWorkspace =
+  mongoose.models.UserWorkspace ||
+  mongoose.model<IUserWorkspace>("UserWorkspace", UserWorkspaceSchema);

--- a/services/db/models/userworkspace.model.ts
+++ b/services/db/models/userworkspace.model.ts
@@ -22,7 +22,6 @@ const UserWorkspaceSchema = new Schema<IUserWorkspace>(
   { timestamps: true },
 );
 
-// Prevent duplicate user-workspace pairs
 UserWorkspaceSchema.index({ workspaceId: 1, userId: 1 }, { unique: true });
 
 export const UserWorkspace =


### PR DESCRIPTION
I realized that by default Better Auth use the OpenID standard for their Slack OAuth authentication logic. So I instead needed to implement it manually using the generic OAuth2.0 plugin Better Auth provides. Here, Ive managed to get it working to the best of my knowledge and want to test the flow before proceeding with the logic of capturing, parsing, and storing the response from Slack